### PR TITLE
Change Access to `tkinter` Namespace and Propagate Canvas Dimensions

### DIFF
--- a/src/dorfromantik_helper/cli.py
+++ b/src/dorfromantik_helper/cli.py
@@ -21,10 +21,14 @@ def main():
         "--load", "-l", action="store_true", help="Load data from last manual save"
     )
     parser.add_argument(
-        "--height", "-y", type=int, help="Pixel height of the board display"
+        "--height",
+        "-y",
+        type=int,
+        default=1000,
+        help="Pixel height of the board display",
     )
     parser.add_argument(
-        "--width", "-x", type=int, help="Pixel width of the board display"
+        "--width", "-x", type=int, default=1300, help="Pixel width of the board display"
     )
     args = parser.parse_args()
 

--- a/src/dorfromantik_helper/ui.py
+++ b/src/dorfromantik_helper/ui.py
@@ -1,6 +1,6 @@
 """Canvas that displays the full game board."""
 # Standard Python Libraries
-from tkinter import Button, Canvas, Frame, Label, Tk
+import tkinter
 
 # Third-Party Libraries
 import numpy as np
@@ -9,11 +9,11 @@ from . import constants
 from .board import DorfBoard
 
 
-class DorfBoardCanvas(Canvas):
+class DorfBoardCanvas(tkinter.Canvas):
     def __init__(
         self, master, board, tile_canvas, pix_height, pix_width, *args, **kwargs
     ):
-        Canvas.__init__(
+        tkinter.Canvas.__init__(
             self,
             master,
             background="white",
@@ -210,14 +210,14 @@ class DorfBoardCanvas(Canvas):
             self.hint_hexes.append((x, y))
 
 
-class HexTileCanvas(Canvas):
+class HexTileCanvas(tkinter.Canvas):
     def __init__(self, master, scale, *args, **kwargs):
         self.x_scale = (scale ** 2 - (scale / 2.0) ** 2) ** 0.5  # hexagon width
         self.y_scale = scale  # half hexagon height
         self.pix_height = 3 * self.y_scale
         self.pix_width = 3 * self.x_scale
 
-        Canvas.__init__(
+        tkinter.Canvas.__init__(
             self,
             master,
             background="white",
@@ -392,19 +392,27 @@ class HexTileCanvas(Canvas):
         self.select_slice(index)
 
 
-class App(Tk):
+class App(tkinter.Tk):
     def __init__(self, from_npz, pix_height, pix_width, *args, **kwargs):
-        Tk.__init__(self, *args, **kwargs)
+        tkinter.Tk.__init__(self, *args, **kwargs)
 
         board = DorfBoard(from_npz=from_npz)
 
         self.canvas_height = pix_height
         self.canvas_width = pix_width
 
-        self.boardview_frame = Frame(self, background="#FFF0C1", bd=1, relief="sunken")
-        self.tile_frame = Frame(self, background="#D2E2FB", bd=1, relief="sunken")
-        self.control_frame = Frame(self, background="#CCE4CA", bd=1, relief="sunken")
-        self.textlog_frame = Frame(self, background="#F5C2C1", bd=1, relief="sunken")
+        self.boardview_frame = tkinter.Frame(
+            self, background="#FFF0C1", bd=1, relief="sunken"
+        )
+        self.tile_frame = tkinter.Frame(
+            self, background="#D2E2FB", bd=1, relief="sunken"
+        )
+        self.control_frame = tkinter.Frame(
+            self, background="#CCE4CA", bd=1, relief="sunken"
+        )
+        self.textlog_frame = tkinter.Frame(
+            self, background="#F5C2C1", bd=1, relief="sunken"
+        )
 
         self.boardview_frame.grid(
             row=0, column=0, columnspan=3, sticky="nsew", padx=2, pady=2
@@ -439,14 +447,28 @@ class App(Tk):
 
         board_controls = []
         frame = self.control_frame
-        board_controls.append(Button(frame, text="Place", command=self.place_tile))
-        board_controls.append(Button(frame, text="Hint", command=self.display_hint))
-        board_controls.append(Button(frame, text="Sample", command=self.sample_tile))
-        board_controls.append(Button(frame, text="Remove", command=self.remove_tile))
-        board_controls.append(Button(frame, text="Undo", command=self.undo))
-        board_controls.append(Button(frame, text="Stats", command=self.display_stats))
-        board_controls.append(Button(frame, text="Save", command=self.manual_save))
-        board_controls.append(Button(frame, text="Quit", command=self.correct_quit))
+        board_controls.append(
+            tkinter.Button(frame, text="Place", command=self.place_tile)
+        )
+        board_controls.append(
+            tkinter.Button(frame, text="Hint", command=self.display_hint)
+        )
+        board_controls.append(
+            tkinter.Button(frame, text="Sample", command=self.sample_tile)
+        )
+        board_controls.append(
+            tkinter.Button(frame, text="Remove", command=self.remove_tile)
+        )
+        board_controls.append(tkinter.Button(frame, text="Undo", command=self.undo))
+        board_controls.append(
+            tkinter.Button(frame, text="Stats", command=self.display_stats)
+        )
+        board_controls.append(
+            tkinter.Button(frame, text="Save", command=self.manual_save)
+        )
+        board_controls.append(
+            tkinter.Button(frame, text="Quit", command=self.correct_quit)
+        )
         for i, button in enumerate(board_controls):
             button.grid(row=i, column=0)
 
@@ -454,31 +476,45 @@ class App(Tk):
         frame = self.control_frame
         fn = self.tile_canvas.set_selected_edge
         tile_controls.append(
-            Button(frame, text="ALL", command=self.tile_canvas.select_all)
+            tkinter.Button(frame, text="ALL", command=self.tile_canvas.select_all)
         )
         tile_controls.append(
-            Button(frame, text="Grass", command=lambda: fn(constants.TileEdge.GRASS))
+            tkinter.Button(
+                frame, text="Grass", command=lambda: fn(constants.TileEdge.GRASS)
+            )
         )
         tile_controls.append(
-            Button(frame, text="Trees", command=lambda: fn(constants.TileEdge.TREES))
+            tkinter.Button(
+                frame, text="Trees", command=lambda: fn(constants.TileEdge.TREES)
+            )
         )
         tile_controls.append(
-            Button(frame, text="House", command=lambda: fn(constants.TileEdge.HOUSE))
+            tkinter.Button(
+                frame, text="House", command=lambda: fn(constants.TileEdge.HOUSE)
+            )
         )
         tile_controls.append(
-            Button(frame, text="Crops", command=lambda: fn(constants.TileEdge.CROPS))
+            tkinter.Button(
+                frame, text="Crops", command=lambda: fn(constants.TileEdge.CROPS)
+            )
         )
         tile_controls.append(
-            Button(frame, text="River", command=lambda: fn(constants.TileEdge.RIVER))
+            tkinter.Button(
+                frame, text="River", command=lambda: fn(constants.TileEdge.RIVER)
+            )
         )
         tile_controls.append(
-            Button(frame, text="Train", command=lambda: fn(constants.TileEdge.TRAIN))
+            tkinter.Button(
+                frame, text="Train", command=lambda: fn(constants.TileEdge.TRAIN)
+            )
         )
         tile_controls.append(
-            Button(frame, text="Water", command=lambda: fn(constants.TileEdge.WATER))
+            tkinter.Button(
+                frame, text="Water", command=lambda: fn(constants.TileEdge.WATER)
+            )
         )
         tile_controls.append(
-            Button(
+            tkinter.Button(
                 frame, text="Station", command=lambda: fn(constants.TileEdge.STATION)
             )
         )
@@ -488,14 +524,14 @@ class App(Tk):
         rotate_controls = []
         frame = self.control_frame
         rotate_controls.append(
-            Button(
+            tkinter.Button(
                 frame,
                 text="Rotate CW",
                 command=lambda: self.tile_canvas.rotate(reverse=False),
             )
         )
         rotate_controls.append(
-            Button(
+            tkinter.Button(
                 frame,
                 text="Rotate CCW",
                 command=lambda: self.tile_canvas.rotate(reverse=True),
@@ -504,7 +540,7 @@ class App(Tk):
         for i, button in enumerate(rotate_controls):
             button.grid(row=i, column=2)
 
-        self.log = Label(self.textlog_frame, text="")
+        self.log = tkinter.Label(self.textlog_frame, text="")
         self.log.pack()
 
         self.can_undo = False

--- a/src/dorfromantik_helper/ui.py
+++ b/src/dorfromantik_helper/ui.py
@@ -1,6 +1,6 @@
 """Canvas that displays the full game board."""
 # Standard Python Libraries
-import tkinter
+import tkinter as tk
 
 # Third-Party Libraries
 import numpy as np
@@ -9,11 +9,11 @@ from . import constants
 from .board import DorfBoard
 
 
-class DorfBoardCanvas(tkinter.Canvas):
+class DorfBoardCanvas(tk.Canvas):
     def __init__(
         self, master, board, tile_canvas, pix_height, pix_width, *args, **kwargs
     ):
-        tkinter.Canvas.__init__(
+        tk.Canvas.__init__(
             self,
             master,
             background="white",
@@ -210,14 +210,14 @@ class DorfBoardCanvas(tkinter.Canvas):
             self.hint_hexes.append((x, y))
 
 
-class HexTileCanvas(tkinter.Canvas):
+class HexTileCanvas(tk.Canvas):
     def __init__(self, master, scale, *args, **kwargs):
         self.x_scale = (scale ** 2 - (scale / 2.0) ** 2) ** 0.5  # hexagon width
         self.y_scale = scale  # half hexagon height
         self.pix_height = 3 * self.y_scale
         self.pix_width = 3 * self.x_scale
 
-        tkinter.Canvas.__init__(
+        tk.Canvas.__init__(
             self,
             master,
             background="white",
@@ -392,27 +392,21 @@ class HexTileCanvas(tkinter.Canvas):
         self.select_slice(index)
 
 
-class App(tkinter.Tk):
+class App(tk.Tk):
     def __init__(self, from_npz, pix_height, pix_width, *args, **kwargs):
-        tkinter.Tk.__init__(self, *args, **kwargs)
+        tk.Tk.__init__(self, *args, **kwargs)
 
         board = DorfBoard(from_npz=from_npz)
 
         self.canvas_height = pix_height
         self.canvas_width = pix_width
 
-        self.boardview_frame = tkinter.Frame(
+        self.boardview_frame = tk.Frame(
             self, background="#FFF0C1", bd=1, relief="sunken"
         )
-        self.tile_frame = tkinter.Frame(
-            self, background="#D2E2FB", bd=1, relief="sunken"
-        )
-        self.control_frame = tkinter.Frame(
-            self, background="#CCE4CA", bd=1, relief="sunken"
-        )
-        self.textlog_frame = tkinter.Frame(
-            self, background="#F5C2C1", bd=1, relief="sunken"
-        )
+        self.tile_frame = tk.Frame(self, background="#D2E2FB", bd=1, relief="sunken")
+        self.control_frame = tk.Frame(self, background="#CCE4CA", bd=1, relief="sunken")
+        self.textlog_frame = tk.Frame(self, background="#F5C2C1", bd=1, relief="sunken")
 
         self.boardview_frame.grid(
             row=0, column=0, columnspan=3, sticky="nsew", padx=2, pady=2
@@ -447,28 +441,16 @@ class App(tkinter.Tk):
 
         board_controls = []
         frame = self.control_frame
+        board_controls.append(tk.Button(frame, text="Place", command=self.place_tile))
+        board_controls.append(tk.Button(frame, text="Hint", command=self.display_hint))
+        board_controls.append(tk.Button(frame, text="Sample", command=self.sample_tile))
+        board_controls.append(tk.Button(frame, text="Remove", command=self.remove_tile))
+        board_controls.append(tk.Button(frame, text="Undo", command=self.undo))
         board_controls.append(
-            tkinter.Button(frame, text="Place", command=self.place_tile)
+            tk.Button(frame, text="Stats", command=self.display_stats)
         )
-        board_controls.append(
-            tkinter.Button(frame, text="Hint", command=self.display_hint)
-        )
-        board_controls.append(
-            tkinter.Button(frame, text="Sample", command=self.sample_tile)
-        )
-        board_controls.append(
-            tkinter.Button(frame, text="Remove", command=self.remove_tile)
-        )
-        board_controls.append(tkinter.Button(frame, text="Undo", command=self.undo))
-        board_controls.append(
-            tkinter.Button(frame, text="Stats", command=self.display_stats)
-        )
-        board_controls.append(
-            tkinter.Button(frame, text="Save", command=self.manual_save)
-        )
-        board_controls.append(
-            tkinter.Button(frame, text="Quit", command=self.correct_quit)
-        )
+        board_controls.append(tk.Button(frame, text="Save", command=self.manual_save))
+        board_controls.append(tk.Button(frame, text="Quit", command=self.correct_quit))
         for i, button in enumerate(board_controls):
             button.grid(row=i, column=0)
 
@@ -476,45 +458,31 @@ class App(tkinter.Tk):
         frame = self.control_frame
         fn = self.tile_canvas.set_selected_edge
         tile_controls.append(
-            tkinter.Button(frame, text="ALL", command=self.tile_canvas.select_all)
+            tk.Button(frame, text="ALL", command=self.tile_canvas.select_all)
         )
         tile_controls.append(
-            tkinter.Button(
-                frame, text="Grass", command=lambda: fn(constants.TileEdge.GRASS)
-            )
+            tk.Button(frame, text="Grass", command=lambda: fn(constants.TileEdge.GRASS))
         )
         tile_controls.append(
-            tkinter.Button(
-                frame, text="Trees", command=lambda: fn(constants.TileEdge.TREES)
-            )
+            tk.Button(frame, text="Trees", command=lambda: fn(constants.TileEdge.TREES))
         )
         tile_controls.append(
-            tkinter.Button(
-                frame, text="House", command=lambda: fn(constants.TileEdge.HOUSE)
-            )
+            tk.Button(frame, text="House", command=lambda: fn(constants.TileEdge.HOUSE))
         )
         tile_controls.append(
-            tkinter.Button(
-                frame, text="Crops", command=lambda: fn(constants.TileEdge.CROPS)
-            )
+            tk.Button(frame, text="Crops", command=lambda: fn(constants.TileEdge.CROPS))
         )
         tile_controls.append(
-            tkinter.Button(
-                frame, text="River", command=lambda: fn(constants.TileEdge.RIVER)
-            )
+            tk.Button(frame, text="River", command=lambda: fn(constants.TileEdge.RIVER))
         )
         tile_controls.append(
-            tkinter.Button(
-                frame, text="Train", command=lambda: fn(constants.TileEdge.TRAIN)
-            )
+            tk.Button(frame, text="Train", command=lambda: fn(constants.TileEdge.TRAIN))
         )
         tile_controls.append(
-            tkinter.Button(
-                frame, text="Water", command=lambda: fn(constants.TileEdge.WATER)
-            )
+            tk.Button(frame, text="Water", command=lambda: fn(constants.TileEdge.WATER))
         )
         tile_controls.append(
-            tkinter.Button(
+            tk.Button(
                 frame, text="Station", command=lambda: fn(constants.TileEdge.STATION)
             )
         )
@@ -524,14 +492,14 @@ class App(tkinter.Tk):
         rotate_controls = []
         frame = self.control_frame
         rotate_controls.append(
-            tkinter.Button(
+            tk.Button(
                 frame,
                 text="Rotate CW",
                 command=lambda: self.tile_canvas.rotate(reverse=False),
             )
         )
         rotate_controls.append(
-            tkinter.Button(
+            tk.Button(
                 frame,
                 text="Rotate CCW",
                 command=lambda: self.tile_canvas.rotate(reverse=True),
@@ -540,7 +508,7 @@ class App(tkinter.Tk):
         for i, button in enumerate(rotate_controls):
             button.grid(row=i, column=2)
 
-        self.log = tkinter.Label(self.textlog_frame, text="")
+        self.log = tk.Label(self.textlog_frame, text="")
         self.log.pack()
 
         self.can_undo = False

--- a/src/dorfromantik_helper/ui.py
+++ b/src/dorfromantik_helper/ui.py
@@ -11,14 +11,7 @@ from .board import DorfBoard
 
 class DorfBoardCanvas(Canvas):
     def __init__(
-        self,
-        master,
-        board,
-        tile_canvas,
-        pix_width=1300,
-        pix_height=1000,
-        *args,
-        **kwargs
+        self, master, board, tile_canvas, pix_height, pix_width, *args, **kwargs
     ):
         Canvas.__init__(
             self,
@@ -405,6 +398,9 @@ class App(Tk):
 
         board = DorfBoard(from_npz=from_npz)
 
+        self.canvas_height = pix_height
+        self.canvas_width = pix_width
+
         self.boardview_frame = Frame(self, background="#FFF0C1", bd=1, relief="sunken")
         self.tile_frame = Frame(self, background="#D2E2FB", bd=1, relief="sunken")
         self.control_frame = Frame(self, background="#CCE4CA", bd=1, relief="sunken")
@@ -431,7 +427,11 @@ class App(Tk):
         self.tile_canvas.grid(row=0, column=0)
 
         self.board_canvas = DorfBoardCanvas(
-            self.boardview_frame, board=board, tile_canvas=self.tile_canvas
+            self.boardview_frame,
+            board=board,
+            tile_canvas=self.tile_canvas,
+            pix_height=self.canvas_height,
+            pix_width=self.canvas_width,
         )
         self.board_canvas.bind("<Button-1>", self.board_canvas.on_click)
         self.board_canvas.grid(row=0, column=0, padx=5, pady=5)
@@ -517,7 +517,11 @@ class App(Tk):
         if self.can_undo:
             board = DorfBoard(from_npz=constants.AUTO_SAVE_FILEPATH)
             self.board_canvas = DorfBoardCanvas(
-                self.boardview_frame, board=board, tile_canvas=self.tile_canvas
+                self.boardview_frame,
+                board=board,
+                tile_canvas=self.tile_canvas,
+                pix_height=self.canvas_height,
+                pix_width=self.canvas_width,
             )
             self.board_canvas.bind("<Button-1>", self.board_canvas.on_click)
             self.board_canvas.grid(row=0, column=0, padx=5, pady=5)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR switches to accessing the `tkinter` namespace as `tk` to improve code flexibility and reduce cluttering this package's namespace. It also updates to set default canvas dimensions using the `argparse` configuration. This allows them to be set in one place and it now propagates down to canvas instantiation.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

You could not set the display dimensions using the command line arguments.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
I confirmed that providing dimensions when calling the package correctly configured the board Canvas.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] All relevant type-of-change labels have been added.
* [x] All new and existing tests pass.
